### PR TITLE
Action to check forbidden files

### DIFF
--- a/.github/workflows/pr-file-check.yml
+++ b/.github/workflows/pr-file-check.yml
@@ -1,4 +1,4 @@
-name: PR File Check
+name: pr-file-check
 
 on:
   pull_request:
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: verify-version
+      - name: Check changed files
         uses: actions-cool/verify-files-modify@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-file-check.yml
+++ b/.github/workflows/pr-file-check.yml
@@ -3,6 +3,7 @@ name: pr-file-check
 on:
   pull_request:
     types:
+      - review_requested
       - synchronize # Checks any commits made to the PR
 
 jobs:

--- a/.github/workflows/pr-file-check.yml
+++ b/.github/workflows/pr-file-check.yml
@@ -1,0 +1,20 @@
+name: PR File Check
+
+on:
+  pull_request:
+    types:
+      - synchronize # Checks any commits made to the PR
+
+jobs:
+  check-files:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: verify-version
+        uses: actions-cool/verify-files-modify@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          forbid-files: "docs/index.html, docs/home.md, requirements.txt, CNAME, LICENSE"
+          forbid-paths: "docs/_logos/, images"
+          # Disables closing the PR if the checks pass
+          close: false


### PR DESCRIPTION
*What?*
- Added an action that checked certain files were not changed in a PR.

*Why?*
- Changing certain files in the PR could allow corruption and would require additional effort to restore the repository.

*Testing*
- I made changes to all the files in the forbid-files input and the check `failed`.
- I made changes to the forbid-paths input and the check `failed`.
- I made changes to the ace_pro/docs/images files and the check `passed`.
- I made changes to the ace_pro/home.md files and the check `passed`.
- I made changes to the docs/ace-pro/_images and the check `passed`.