### PR TITLE
Add git status check

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -60,9 +60,12 @@ jobs:
           git config user.email "<>"
 
       - name: Commit Files
-
         run: |
-          # Stage the file, commit and push
-          git add .
-          git commit -m "auto build from GitHub Actions"
-          git push origin ${{ github.event.pull_request.head.ref }}
+          if [[ -n $(git status -s) ]]; then
+            # Stage the file, commit and push
+            git add .
+            git commit -m "auto build from GitHub Actions"
+            git push origin ${{ github.event.pull_request.head.ref }}
+          else
+            echo "No changes since last run"
+          fi


### PR DESCRIPTION
*What?*
- Add check for clean commit tree.

*Why?*
- Auto Build script would fail to build if the commit tree was empty.